### PR TITLE
fix: reporting workflow artifact download

### DIFF
--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -11,12 +11,14 @@ jobs:
   Coverage:
     runs-on: ubuntu-latest
     steps:
+    - name: Display Event
+      run: echo "${{ toJson(github.event) }}"
 
     - name: Download Results Artifacts
       uses: dawidd6/action-download-artifact@v2
       with:
-        workflow: Testing
-        workflow_conclusion: completed
+        workflow: ${{ github.event.workflow.id }}
+        run_id: ${{ github.event.workflow_run.id }}
 
     - name: Setup Code Coverage
       run: |


### PR DESCRIPTION
Specify the run_id of the triggering workflow

Fixes #22